### PR TITLE
Brand migration: Update org references ambiware-labs → loqalabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Loqa Core contains the foundational components for building and running a distri
 Loqa is an open-source ambient intelligence platform designed to run locally, adapt to your life, and respect your data.
 
 - **Composable Open Core:** The runtime, protocols, and tooling stay MIT-licensed forever. You can self-host, fork, and embed without restrictions.
-- **Modular extensibility:** Skills and adapters plug in like VS Code extensions. Start with the [authoring guide](skills/AUTHORING_GUIDE.md) and the [skills spec](https://github.com/ambiware-labs/loqa-core/blob/main/docs/skills/SPEC.md).
+- **Modular extensibility:** Skills and adapters plug in like VS Code extensions. Start with the [authoring guide](skills/AUTHORING_GUIDE.md) and the [skills spec](https://github.com/loqalabs/loqa-core/blob/main/docs/skills/SPEC.md).
 - **Loqa Studio add-ons:** Optional persona packs, premium skills, encrypted Loqa Cloud sync, and support subscriptions enrich the experience without gating your freedom.
 
 We call this model **Composable Open Core**, backed by a commitment to **ethical monetization**. No bait-and-switch. No forced telemetry. No locked-in silos. Just intelligent software you can trust—and build on.
 
-Want to contribute? Explore the [Extension Labs resources](https://github.com/ambiware-labs/loqa-meta/blob/main/community/extension-labs/README.md), read the [contributor guide](https://github.com/ambiware-labs/loqa-meta/blob/main/community/contributing-guide.md), or weigh in on the marketplace RFC ([RFC-0003](https://github.com/ambiware-labs/loqa-meta/blob/main/rfcs/RFC-0003_loqa_marketplace_mvp.md)).
+Want to contribute? Explore the [Extension Labs resources](https://github.com/loqalabs/loqa-meta/blob/main/community/extension-labs/README.md), read the [contributor guide](https://github.com/loqalabs/loqa-meta/blob/main/community/contributing-guide.md), or weigh in on the marketplace RFC ([RFC-0003](https://github.com/loqalabs/loqa-meta/blob/main/rfcs/RFC-0003_loqa_marketplace_mvp.md)).
 
 ## Downloads
 
-- **Nightly snapshots:** Every day the [Nightly builds](https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml) workflow publishes artifacts that contain precompiled `loqad`, `loqa-skill`, sample configs, docs, and the TinyGo example skill packages. Download the archive that matches your platform (e.g., `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`), verify it with the accompanying `.sha256`, and extract it with `tar -xzf`.
-- **Tagged releases:** Pushing a `v*` tag produces versioned bundles via the [Release workflow](https://github.com/ambiware-labs/loqa-core/actions/workflows/release.yml). These are attached automatically to the corresponding GitHub Release page.
+- **Nightly snapshots:** Every day the [Nightly builds](https://github.com/loqalabs/loqa-core/actions/workflows/nightly.yml) workflow publishes artifacts that contain precompiled `loqad`, `loqa-skill`, sample configs, docs, and the TinyGo example skill packages. Download the archive that matches your platform (e.g., `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`), verify it with the accompanying `.sha256`, and extract it with `tar -xzf`.
+- **Tagged releases:** Pushing a `v*` tag produces versioned bundles via the [Release workflow](https://github.com/loqalabs/loqa-core/actions/workflows/release.yml). These are attached automatically to the corresponding GitHub Release page.
 
 ## Getting Started
 

--- a/cmd/loqa-skill/main.go
+++ b/cmd/loqa-skill/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+	"github.com/loqalabs/loqa-core/internal/skills/manifest"
 )
 
 var version = "0.1.0-dev"

--- a/cmd/loqad/main.go
+++ b/cmd/loqad/main.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/runtime"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/runtime"
 )
 
 var version = "0.1.0-dev"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,4 +96,4 @@ For implementation details, review:
 - [`docs/GETTING_STARTED.md`](GETTING_STARTED.md) for the sample pipeline walkthrough
 - [`skills/AUTHORING_GUIDE.md`](../skills/AUTHORING_GUIDE.md) to build and package new skills
 
-Community discussions and RFCs live in the [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta) repository.
+Community discussions and RFCs live in the [`loqa-meta`](https://github.com/loqalabs/loqa-meta) repository.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -17,7 +17,7 @@ Welcome! This guide walks you through running the Loqa runtime locally with the 
 
 If you want to skip building the binaries manually, grab the latest snapshot artifact:
 
-1. Visit the [Nightly builds workflow](https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml) and open the most recent successful run.
+1. Visit the [Nightly builds workflow](https://github.com/loqalabs/loqa-core/actions/workflows/nightly.yml) and open the most recent successful run.
 2. Download the archive that matches your platform, for example `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`.
 3. (Recommended) Validate the checksum with `shasum -a 256 -c loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz.sha256`.
 4. Extract the bundle and add the binaries to your `PATH`:
@@ -31,7 +31,7 @@ You can perform the same download via the GitHub CLI:
 
 ```bash
 gh run download \
-  --repo ambiware-labs/loqa-core \
+  --repo loqalabs/loqa-core \
   --workflow nightly.yml \
   --latest \
   --name nightly-YYYYMMDD-linux-amd64
@@ -50,7 +50,7 @@ Leave this running in its own terminal. (If you already run NATS elsewhere, upda
 ## 2. Clone the repository
 
 ```bash
-git clone https://github.com/ambiware-labs/loqa-core.git
+git clone https://github.com/loqalabs/loqa-core.git
 cd loqa-core
 ```
 
@@ -160,8 +160,8 @@ Once validated you can swap the simulated transcript publishing for real PCM fra
 ## 8. Next steps
 
 - **Read the Skills Runtime Guide:** Dive into manifests, permissions, and how to build your own WASM modules in [`skills/README.md`](../skills/README.md).
-- **Check the MVP Backlog:** See what’s planned in [`loqa-meta`](https://github.com/ambiware-labs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md).
-- **Join Discussions:** Share ideas or ask questions in [GitHub Discussions](https://github.com/ambiware-labs/loqa-core/discussions).
+- **Check the MVP Backlog:** See what’s planned in [`loqa-meta`](https://github.com/loqalabs/loqa-meta/blob/main/roadmap/MVP_BACKLOG.md).
+- **Join Discussions:** Share ideas or ask questions in [GitHub Discussions](https://github.com/loqalabs/loqa-core/discussions).
 - **Try observability:** Spin up the Grafana/Tempo/Loki stack with `make -C observability docker-up` and watch traces/metrics.
 
 ## Troubleshooting

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -36,7 +36,7 @@ brew install nats-io/nats/nats
 
 ### Option A: Download a nightly archive
 
-1. Visit the [Nightly builds workflow](https://github.com/ambiware-labs/loqa-core/actions/workflows/nightly.yml) and open the latest successful run.
+1. Visit the [Nightly builds workflow](https://github.com/loqalabs/loqa-core/actions/workflows/nightly.yml) and open the latest successful run.
 2. Download the artifact bundle that matches your platform (e.g., `loqa-core_nightly-YYYYMMDD_linux_amd64.tar.gz`).
 3. Verify integrity:
 
@@ -54,7 +54,7 @@ You can perform the same download with the GitHub CLI:
 
 ```bash
 gh run download \
-  --repo ambiware-labs/loqa-core \
+  --repo loqalabs/loqa-core \
   --workflow nightly.yml \
   --latest \
   --name nightly-YYYYMMDD-linux-amd64
@@ -63,7 +63,7 @@ gh run download \
 ### Option B: Build from source
 
 ```bash
-git clone https://github.com/ambiware-labs/loqa-core.git
+git clone https://github.com/loqalabs/loqa-core.git
 cd loqa-core
 make skills            # compiles TinyGo examples and validates manifests
 make run               # builds and launches the runtime with the example config

--- a/docs/skills/SPEC.md
+++ b/docs/skills/SPEC.md
@@ -138,8 +138,8 @@ The host records `skill.invoke.start`, `skill.invoke.error`, and `skill.invoke.c
 
 Open questions and future work are tracked in:
 
-- [loqa-core#37](https://github.com/ambiware-labs/loqa-core/issues/37) – skills spec evolution
-- [loqa-meta#26](https://github.com/ambiware-labs/loqa-meta/issues/26) – marketplace RFC
-- [loqa-meta#27](https://github.com/ambiware-labs/loqa-meta/issues/27) – Extension Labs resources
+- [loqa-core#37](https://github.com/loqalabs/loqa-core/issues/37) – skills spec evolution
+- [loqa-meta#26](https://github.com/loqalabs/loqa-meta/issues/26) – marketplace RFC
+- [loqa-meta#27](https://github.com/loqalabs/loqa-meta/issues/27) – Extension Labs resources
 
 If you need additional host capabilities, open a discussion or RFC in `loqa-meta`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ambiware-labs/loqa-core
+module github.com/loqalabs/loqa-core
 
 go 1.24.3
 

--- a/internal/bus/client.go
+++ b/internal/bus/client.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 	"github.com/nats-io/nats.go"
 )
 

--- a/internal/capability/registry.go
+++ b/internal/capability/registry.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
 	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -63,7 +63,7 @@ func NewRegistry(ctx context.Context, cfg config.NodeConfig, busClient *bus.Clie
 		log:    log.With(slog.String("component", "capability-registry")),
 		bus:    busClient,
 		nodes:  make(map[string]*NodeInfo),
-		meter:  otel.Meter("github.com/ambiware-labs/loqa-core/runtime"),
+		meter:  otel.Meter("github.com/loqalabs/loqa-core/runtime"),
 		cancel: cancel,
 	}
 

--- a/internal/eventstore/store.go
+++ b/internal/eventstore/store.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 	_ "modernc.org/sqlite"
 )
 

--- a/internal/eventstore/store_test.go
+++ b/internal/eventstore/store_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 )
 
 func newLogger() *slog.Logger {

--- a/internal/llm/service.go
+++ b/internal/llm/service.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/protocol"
 	"github.com/nats-io/nats.go"
 )
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 )
 
 // Request describes a language model prompt.

--- a/internal/router/service.go
+++ b/internal/router/service.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/protocol"
 	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -46,8 +46,8 @@ type sessionState struct {
 
 func NewService(parent context.Context, cfg config.RouterConfig, busClient *bus.Client, logger *slog.Logger) *Service {
 	ctx, cancel := context.WithCancel(parent)
-	tracer := otel.Tracer("github.com/ambiware-labs/loqa-core/router")
-	meter := otel.Meter("github.com/ambiware-labs/loqa-core/router")
+	tracer := otel.Tracer("github.com/loqalabs/loqa-core/router")
+	meter := otel.Meter("github.com/loqalabs/loqa-core/router")
 
 	hist, err := meter.Float64Histogram(
 		"loqa.voice_latency_ms",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -9,15 +9,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/capability"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/eventstore"
-	"github.com/ambiware-labs/loqa-core/internal/llm"
-	"github.com/ambiware-labs/loqa-core/internal/router"
-	skillservice "github.com/ambiware-labs/loqa-core/internal/skills/service"
-	"github.com/ambiware-labs/loqa-core/internal/stt"
-	"github.com/ambiware-labs/loqa-core/internal/tts"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/capability"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/eventstore"
+	"github.com/loqalabs/loqa-core/internal/llm"
+	"github.com/loqalabs/loqa-core/internal/router"
+	skillservice "github.com/loqalabs/loqa-core/internal/skills/service"
+	"github.com/loqalabs/loqa-core/internal/stt"
+	"github.com/loqalabs/loqa-core/internal/tts"
 )
 
 type Runtime struct {

--- a/internal/runtime/telemetry.go
+++ b/internal/runtime/telemetry.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/skills/runtime/runtime.go
+++ b/internal/skills/runtime/runtime.go
@@ -8,7 +8,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
+	"github.com/loqalabs/loqa-core/internal/skills/manifest"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"

--- a/internal/skills/runtime/runtime_test.go
+++ b/internal/skills/runtime/runtime_test.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ambiware-labs/loqa-core/internal/skills/manifest"
-	runtime "github.com/ambiware-labs/loqa-core/internal/skills/runtime"
+	"github.com/loqalabs/loqa-core/internal/skills/manifest"
+	runtime "github.com/loqalabs/loqa-core/internal/skills/runtime"
 )
 
 const sampleManifest = `metadata:

--- a/internal/skills/service/service.go
+++ b/internal/skills/service/service.go
@@ -13,11 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/eventstore"
-	manifestpkg "github.com/ambiware-labs/loqa-core/internal/skills/manifest"
-	skillrt "github.com/ambiware-labs/loqa-core/internal/skills/runtime"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/eventstore"
+	manifestpkg "github.com/loqalabs/loqa-core/internal/skills/manifest"
+	skillrt "github.com/loqalabs/loqa-core/internal/skills/runtime"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 )

--- a/internal/stt/exec_recognizer.go
+++ b/internal/stt/exec_recognizer.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/ambiware-labs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/config"
 	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 	"github.com/mattn/go-shellwords"

--- a/internal/stt/service.go
+++ b/internal/stt/service.go
@@ -8,9 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/protocol"
 	"github.com/nats-io/nats.go"
 )
 

--- a/internal/tts/service.go
+++ b/internal/tts/service.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/internal/bus"
-	"github.com/ambiware-labs/loqa-core/internal/config"
-	"github.com/ambiware-labs/loqa-core/internal/protocol"
+	"github.com/loqalabs/loqa-core/internal/bus"
+	"github.com/loqalabs/loqa-core/internal/config"
+	"github.com/loqalabs/loqa-core/internal/protocol"
 	"github.com/nats-io/nats.go"
 )
 

--- a/skills/examples/smart-home/src/main.go
+++ b/skills/examples/smart-home/src/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+	"github.com/loqalabs/loqa-core/skills/examples/internal/host"
 )
 
 type intent struct {

--- a/skills/examples/timer/src/main.go
+++ b/skills/examples/timer/src/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ambiware-labs/loqa-core/skills/examples/internal/host"
+	"github.com/loqalabs/loqa-core/skills/examples/internal/host"
 )
 
 type timerRequest struct {


### PR DESCRIPTION
Updates all references from ambiware-labs to loqalabs as part of brand migration.

**Changes:**
- Updated import paths in Go code
- Updated go.mod module path  
- Updated documentation links
- Updated README and architecture docs

**Migration Phase:** Phase 2.3 - Repository Updates

**Files Changed:** 25 files, 62 insertions(+), 62 deletions(-)

Part of brand migration plan: docs/BRAND-MIGRATION-PLAN.md